### PR TITLE
feat: represent terncy scene as a homeassistant swtich

### DIFF
--- a/terncy/__init__.py
+++ b/terncy/__init__.py
@@ -320,7 +320,14 @@ async def update_or_create_entity_inner(svc, tern, model, version, available):
 
     disableRelay = get_attr_value(attrs, "disableRelay")
     temperature = get_attr_value(attrs, "temperature")
-    if not devid in tern.hass_platform_data.parsed_devices:
+    if devid in tern.hass_platform_data.parsed_devices:
+        device = tern.hass_platform_data.parsed_devices[devid]
+        device.is_available = available
+        if attrs:
+            device.update_state(attrs)
+        if device.hass:
+            device.schedule_update_ha_state()
+    else:
         _LOGGER.info("need to add dev %s %d %s to platform", name, profile, devid)
         if profile == PROFILE_YAN_BUTTON or disableRelay == 1:
             device = TerncyButton(tern, devid, name, model, version, features)

--- a/terncy/switch.py
+++ b/terncy/switch.py
@@ -245,6 +245,90 @@ class TerncySwitch(SwitchEntity):
             },
         ]
 
+class TerncyScene(SwitchEntity):
+    """Representation of a Terncy scene."""
+
+    def __init__(self, api, devid, name, model, version, features):
+        """Initialize the scene."""
+        self._device_id = devid
+        self.hub_id = api.dev_id
+        self._name = name
+        self.model = model
+        self.version = version
+        self.api = api
+        self.is_available = False
+        self._features = features
+        self._onoff = False
+
+    def update_state(self, attrs):
+        """Updateterncy state."""
+        _LOGGER.info("update state event to %s", attrs)
+        on_off = get_attr_value(attrs, "on")
+        if on_off is not None:
+            self._onoff = on_off == 1
+
+    @property
+    def unique_id(self):
+        """Return terncy unique id."""
+        return self._device_id
+
+    @property
+    def device_id(self):
+        """Return terncy device id."""
+        return self._device_id
+
+    @property
+    def device_class(self):
+        """Return if terncy device is available."""
+        return DEVICE_CLASS_OUTLET
+
+    @property
+    def name(self):
+        """Return terncy device name."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return if terncy device is on."""
+        return self._onoff
+
+    @property
+    def available(self):
+        """Return if terncy device is available."""
+        return self.is_available
+
+    @property
+    def supported_features(self):
+        """Return the terncy device feature."""
+        return self._features
+
+    @property
+    def device_info(self):
+        """Return the terncy device info."""
+        return {
+            "identifiers": {(DOMAIN, self.device_id)},
+            "connections": {(dr.CONNECTION_ZIGBEE, self.device_id)},
+            "name": self.name,
+            "manufacturer": TERNCY_MANU_NAME,
+            "model": self.model,
+            "sw_version": self.version,
+            "via_device": (DOMAIN, self.hub_id),
+        }
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on terncy smart plug."""
+        _LOGGER.info("turn on %s", kwargs)
+        self._onoff = True
+        await self.api.set_onoff(self._device_id, 1)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off terncy smart plug."""
+        _LOGGER.info("turn off")
+        self._onoff = False
+        await self.api.set_onoff(self._device_id, 0)
+        self.async_write_ha_state()
+
 class TerncyButton(ButtonEntity):
     """Representation of a Terncy Stateless Button."""
 

--- a/terncy/switch.py
+++ b/terncy/switch.py
@@ -280,7 +280,7 @@ class TerncyScene(SwitchEntity):
     @property
     def device_class(self):
         """Return if terncy device is available."""
-        return DEVICE_CLASS_OUTLET
+        return DEVICE_CLASS_SWITCH
 
     @property
     def name(self):

--- a/terncy/utils.py
+++ b/terncy/utils.py
@@ -2,6 +2,8 @@
 
 def get_attr_value(attrs, key):
     """Read attr value from terncy attributes."""
+    if attrs is None:
+        return None
     for att in attrs:
         if "attr" in att and att["attr"] == key:
             return att["value"]


### PR DESCRIPTION
- Get and parse terncy scene entities
- Represent the secne as a switch in homeassistant so that it can be turned on and off

Terncy app is more powerful to define actions and combinations than home assistant in some use cases since the app is optimized to controlling Terncy devices. With this feature, I can create a scene to do complex actions and port it in homeassistant. I tested locally and it works smoothly.


This PR also fixes a bug introduced by 9917275701646041debaf8353222d7c54df71eaf:
- device state is not updated on receiving entity avaiable message


close #24 
