### PR TITLE
remove unnecessary code

### DIFF
--- a/terncy/__init__.py
+++ b/terncy/__init__.py
@@ -521,5 +521,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_remove_config_entry_device(hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry) -> bool:
     # reference: https://developers.home-assistant.io/docs/device_registry_index/#removing-devices
-    dr.async_get(hass).async_remove_device(device_entry.id)
     return True


### PR DESCRIPTION
查阅了一下HA调用此处的代码，这行手动移除的代码是不需要的，这边只需做一些清理工作，HA内部在后续会执行移除操作。

https://github.com/home-assistant/core/blob/dev/homeassistant/components/config/device_registry.py#L131

https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/device_registry.py#L497