### PR TITLE
初始化时候读取设备名字

### DIFF
--- a/custom_components/terncy/__init__.py
+++ b/custom_components/terncy/__init__.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceEntry

--- a/custom_components/terncy/climate.py
+++ b/custom_components/terncy/climate.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
-)
-from homeassistant.components.climate.const import (
     ClimateEntityFeature,
     FAN_HIGH,
     FAN_LOW,
@@ -18,13 +16,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UndefinedType
 
-from custom_components.terncy.const import (
+from .const import (
     DOMAIN,
     FROZEN_ENTITY_DESCRIPTION,
     TerncyEntityDescription,
 )
-from custom_components.terncy.core.entity import TerncyEntity, create_entity_setup
-from custom_components.terncy.utils import get_attr_value
+from .core.entity import TerncyEntity, create_entity_setup
+from .utils import get_attr_value
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/terncy/const.py
+++ b/custom_components/terncy/const.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, Platform
 from homeassistant.helpers.entity import EntityDescription
 
-from custom_components.terncy.types import AttrValue
+from .types import AttrValue
 
 DOMAIN = "terncy"
 HA_CLIENT_ID = "homeass_nbhQ43"

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -226,7 +226,6 @@ class TerncyGateway:
         return ret
 
     async def set_attributes(self, eid: str, attrs: list[AttrValue], method=0):
-        _LOGGER.info(eid)
         ret = await self.api.set_attributes(eid, attrs, method)
         self.update_listeners(eid, attrs)
         return ret
@@ -276,7 +275,7 @@ class TerncyGateway:
                 )
 
         elif isinstance(event, Connected):
-            _LOGGER.warning("[%s] Connected.", api.dev_id)
+            _LOGGER.info("[%s] Connected.", api.dev_id)
             self.async_create_task(self.async_refresh_devices())
 
         elif isinstance(event, Disconnected):

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -503,7 +503,12 @@ class TerncyGateway:
 
         for svc in svc_list:
             eid = svc["id"]
-            name = svc["name"] or eid  # some name is ""
+            name = svc["name"]
+            if not name:  # some name is ""
+                if device_name := device_data.get("name"):
+                    name = f"{device_name}-{eid[-2:]}"  # 'device_name-04'
+                else:
+                    name = eid
             attributes = svc.get("attributes", [])
 
             device = self.parsed_devices.get(eid)

--- a/custom_components/terncy/types.py
+++ b/custom_components/terncy/types.py
@@ -36,6 +36,7 @@ class PhysicalDeviceData(TypedDict):
     version: int
     hwVersion: int
 
+    name: str | None  # Hub version >= 3.2.14
     services: list[SvcData] | None
     online: bool
 


### PR DESCRIPTION
一个很小的更新，如果网关固件>=3.2.14，初始化拉取设备列表的时候，会读取在小燕app上自定义的设备名字，
可以解决一些 `按键数量多于继电器数量的开关` 的自动命名问题。
（比如青鸾·零火三开的第4个键，之前是用序列号命名的，现在应该会是`设备名字-04`这样）

**需要将网关固件升级到 3.2.14（开发版）**