### PR TITLE
Revert the generated entity_id style

### DIFF
--- a/custom_components/terncy/__init__.py
+++ b/custom_components/terncy/__init__.py
@@ -1,4 +1,5 @@
 """The Terncy integration."""
+
 import logging
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/terncy/config_flow.py
+++ b/custom_components/terncy/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Terncy integration."""
+
 import logging
 import uuid
 from typing import Any

--- a/custom_components/terncy/const.py
+++ b/custom_components/terncy/const.py
@@ -1,11 +1,6 @@
 """Constants for the Terncy integration."""
-from dataclasses import dataclass
-from typing import TypedDict
 
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, Platform
-from homeassistant.helpers.entity import EntityDescription
-
-from .types import AttrValue
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
 
 DOMAIN = "terncy"
 HA_CLIENT_ID = "homeass_nbhQ43"
@@ -109,40 +104,6 @@ EVENT_ENTITY_DIAL_EVENTS = [
     *_PRESS_EVENTS,
     ACTION_ROTATION,
 ]
-
-# https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes
-FROZEN_ENTITY_DESCRIPTION = MAJOR_VERSION >= 2024
-
-
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class TerncyEntityDescription(EntityDescription):
-    PLATFORM: Platform = None
-
-    sub_key: str | None = None
-    """用作 unique_id 的后缀。"""
-
-    unique_id_prefix: str | None = None
-    """用作 unique_id 的前缀。（目前只给scene用，考虑有没有更好的方式）"""
-
-    old_unique_id_suffix: str | None = None  # use for migrate
-
-    translation_key: str | None = None  # <2023.1 需要这一行，避免报错
-
-    required_attrs: list[str] | None = None
-    """需要的属性，如果没有这些属性，就不创建实体"""
-
-
-class TerncyDeviceData(TypedDict):
-    name: str
-    model: str
-    did: str
-    sw_version: str | None
-    hw_version: str | None
-    descriptions: list[TerncyEntityDescription]
-    triggers: list[dict[str, str]]
-
-    online: bool
-    attributes: list[AttrValue]
 
 
 HAS_EVENT_PLATFORM = (MAJOR_VERSION, MINOR_VERSION) >= (2023, 8)  # HA>=2023.8

--- a/custom_components/terncy/core/device.py
+++ b/custom_components/terncy/core/device.py
@@ -1,15 +1,10 @@
 import logging
 from typing import Any
 
-from homeassistant.const import (
-    CONF_DEVICE_ID,
-    CONF_DOMAIN,
-    CONF_PLATFORM,
-    CONF_TYPE,
-)
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 
-from .entity import TerncyEntity
 from ..const import DEVICE_TRIGGER_ACTIONS_MAP, DOMAIN, HAS_EVENT_PLATFORM
+from ..hass.entity import TerncyEntity
 from ..types import AttrValue
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from collections.abc import Callable, Coroutine
-from itertools import groupby
 from typing import ForwardRef
 
 from homeassistant.config_entries import ConfigEntry
@@ -12,18 +11,13 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
-    Platform,
 )
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    Event,
-    HomeAssistant,
-    callback,
-)
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     CONNECTION_ZIGBEE,
+    DeviceInfo,
     format_mac,
 )
 from homeassistant.helpers.typing import UNDEFINED
@@ -31,7 +25,6 @@ from terncy import Terncy
 from terncy.event import Connected, Disconnected, EventMessage
 
 from .device import TerncyDevice
-from .entity import TerncyEntity
 from ..const import (
     ACTION_LONG_PRESS,
     ACTION_PRESSED,
@@ -52,11 +45,12 @@ from ..const import (
     TERNCY_EVENT_SVC_REMOVE,
     TERNCY_HUB_ID_PREFIX,
     TERNCY_MANU_NAME,
-    TerncyEntityDescription,
 )
+from ..hass.add_entities import create_entity, ha_add_entity
+from ..hass.entity import TerncyEntity
+from ..hass.entity_descriptions import TerncyEntityDescription, TerncySwitchDescription
 from ..hub_monitor import TerncyHubManager
 from ..profiles import PROFILES
-from ..switch import TerncySwitchDescription
 from ..types import (
     AttrValue,
     DeviceGroupData,
@@ -94,7 +88,6 @@ class TerncyGateway:
         self.config_entry = config_entry
 
         self.parsed_devices: dict[str, TerncyDevice] = {}  # key: eid
-        self.setups: dict[Platform, SetupHandler] = {}
         self._listeners: dict[str, set[Callable[[list[AttrValue]], None]]] = {}
         self.room_data: dict[str, str] = {}  # room_id: room_name
         self.scenes: dict[str, TerncyEntity] = {}  # 场景实体们
@@ -115,6 +108,7 @@ class TerncyGateway:
             CONF_EXPORT_DEVICE_GROUPS, True
         )
         self.export_scenes = config_entry.options.get(CONF_EXPORT_SCENES, False)
+
         # endregion
 
         async def on_hass_stop(event: Event):
@@ -157,14 +151,20 @@ class TerncyGateway:
                 _LOGGER.warning("service %s %s stopped, don't retry", dev_id, tern.ip)
                 return
 
-            _LOGGER.warning("Reconnect terncy service: %s %s to wait", dev_id, event.data)
+            _LOGGER.warning(
+                "Reconnect terncy service: %s %s to wait", dev_id, event.data
+            )
             await asyncio.sleep(2)
-            _LOGGER.warning("Reconnect terncy service: %s %s after wait", dev_id, event.data)
+            _LOGGER.warning(
+                "Reconnect terncy service: %s %s after wait", dev_id, event.data
+            )
             if not tern.is_connected():
                 _LOGGER.warning("Start connecting %s %s", dev_id, tern.ip)
                 self.async_create_task(setup_terncy_loop())
             else:
-                _LOGGER.warning("service %s %s is still connected while retry", dev_id, event.data)
+                _LOGGER.warning(
+                    "service %s %s is still connected while retry", dev_id, event.data
+                )
 
         def on_terncy_svc_remove(event: Event):
             """Terncy service stop handler"""
@@ -192,7 +192,7 @@ class TerncyGateway:
 
     @property
     def unique_id(self):
-        return self.api.dev_id
+        return self.api.dev_id  # box-12-34-56-78-90-ab
 
     @property
     def is_connected(self):
@@ -221,14 +221,12 @@ class TerncyGateway:
         #     _LOGGER.debug("[%s] no listener for %s", self.unique_id, eid)
 
     async def set_attribute(self, eid: str, attr: str, value, method=0):
-        ret = await self.api.set_attribute(eid, attr, value, method)
+        await self.api.set_attribute(eid, attr, value, method)
         self.update_listeners(eid, [{"attr": attr, "value": value}])
-        return ret
 
     async def set_attributes(self, eid: str, attrs: list[AttrValue], method=0):
-        ret = await self.api.set_attributes(eid, attrs, method)
+        await self.api.set_attributes(eid, attrs, method)
         self.update_listeners(eid, attrs)
-        return ret
 
     # region Event handlers
 
@@ -452,9 +450,6 @@ class TerncyGateway:
 
     # region Setup
 
-    def add_setup(self, platform: Platform, handler: SetupHandler):
-        self.setups[platform] = handler
-
     def add_device(self, eid: str, device: TerncyDevice):
         self.parsed_devices[eid] = device
 
@@ -523,12 +518,14 @@ class TerncyGateway:
                         if svc_room_name := self.room_data.get(svc_room):
                             suggested_area = svc_room_name
                     identifiers = {(DOMAIN, eid)}
-                    all_descriptions = PROFILES.get(profile)
-                    for plat, descs in groupby(all_descriptions, lambda x: x.PLATFORM):
-                        entities = self.setups[plat](
-                            self, identifiers, eid, descs, attributes
-                        )
-                        device.entities.extend(entities)
+                    for description in PROFILES.get(profile):
+                        if (required_attrs := description.required_attrs) is not None:
+                            if not all(attr in attributes for attr in required_attrs):
+                                continue
+                        entity = create_entity(self, eid, description)
+                        entity._attr_device_info = DeviceInfo(identifiers=identifiers)
+                        ha_add_entity(self.hass, self.config_entry, entity)
+                        device.entities.append(entity)
                     if len(device.entities) > 0:
                         device_registry.async_get_or_create(
                             config_entry_id=self.config_entry.entry_id,
@@ -627,33 +624,23 @@ class TerncyGateway:
         name = scene_data.get("name") or scene_id  # some name is ""
         online = scene_data.get("online", True)
 
-        attributes: list[AttrValue] = []
-        if "on" in scene_data:
-            attributes.append({"attr": "on", "value": scene_data["on"]})
-
         entity = self.scenes.get(scene_id)
         if not entity:
-            descriptions = [
-                TerncySwitchDescription(
-                    key="scene",
-                    name=name,
-                    icon="mdi:palette",
-                    unique_id_prefix=self.unique_id,  # scene_id不是uuid形式的，加个网关id作前缀
-                )
-            ]
-            entities = self.setups[Platform.SWITCH](
-                self,
-                {(DOMAIN, f"{self.unique_id}_scenes")},
-                scene_id,
-                descriptions,
-                attributes,
+            description = TerncySwitchDescription(
+                key="scene",
+                name=name,
+                icon="mdi:palette",
+                unique_id_prefix=self.unique_id,  # scene_id不是uuid形式的，加个网关id作前缀
             )
-            entity = entities[0]
+            identifiers = {(DOMAIN, f"{self.unique_id}_scenes")}
+            entity = create_entity(self, scene_id, description)
+            entity._attr_device_info = DeviceInfo(identifiers=identifiers)
+            ha_add_entity(self.hass, self.config_entry, entity)
             self.scenes[scene_id] = entity
         else:
             entity._attr_name = name
 
         entity.set_available(online)
-        entity.update_state(attributes)
+        entity.update_state([{"attr": "on", "value": scene_data["on"]}])
 
     # endregion

--- a/custom_components/terncy/device_trigger.py
+++ b/custom_components/terncy/device_trigger.py
@@ -1,4 +1,5 @@
 """Provides device triggers for Terncy."""
+
 import logging
 
 import voluptuous as vol

--- a/custom_components/terncy/hass/add_entities.py
+++ b/custom_components/terncy/hass/add_entities.py
@@ -1,0 +1,47 @@
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .entity import TerncyEntity
+from .entity_descriptions import TerncyEntityDescription
+from ..const import DOMAIN
+
+if TYPE_CHECKING:
+    from ..core.gateway import TerncyGateway
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def create_entity(
+    gateway: "TerncyGateway",
+    eid: str,
+    description: TerncyEntityDescription,
+) -> TerncyEntity:
+    domain = str(description.PLATFORM)
+    cls = (  # fmt: off
+        TerncyEntity.NEW.get(f"{domain}.key.{description.key}")
+        or TerncyEntity.NEW.get(domain)
+    )
+    return cls(gateway, eid, description)
+
+
+def ha_add_entity(hass: HomeAssistant, config_entry: ConfigEntry, entity: TerncyEntity):
+    """Add entity to HA"""
+    domain = str(entity.entity_description.PLATFORM)
+    config_entry_id = config_entry.entry_id
+    registry = er.async_get(hass)
+    if entity_id := registry.async_get_entity_id(domain, DOMAIN, entity.unique_id):
+        if entity_entry := registry.async_get(entity_id):
+            if entity_entry.config_entry_id != config_entry_id:
+                _LOGGER.debug(
+                    "[%s] entity %s already exists, skip",
+                    entity.gateway.unique_id,
+                    entity.unique_id,
+                )
+                return
+    _LOGGER.debug("[%s] created entity %s", entity.gateway.unique_id, entity.unique_id)
+    async_add_entities = TerncyEntity.ADD[f"{config_entry_id}.{domain}"]
+    async_add_entities([entity], update_before_add=False)

--- a/custom_components/terncy/hass/entity_descriptions.py
+++ b/custom_components/terncy/hass/entity_descriptions.py
@@ -1,0 +1,211 @@
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Callable
+
+from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from homeassistant.components.climate import ClimateEntityDescription
+from homeassistant.components.cover import CoverEntityDescription
+from homeassistant.components.event import EventDeviceClass, EventEntityDescription
+from homeassistant.components.light import (
+    ColorMode,
+    LightEntityDescription,
+    LightEntityFeature,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.const import (
+    EntityCategory,
+    LIGHT_LUX,
+    MAJOR_VERSION,
+    PERCENTAGE,
+    Platform,
+    UnitOfTemperature,
+)
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.typing import StateType, UndefinedType
+
+from ..const import EVENT_ENTITY_BUTTON_EVENTS
+
+
+# https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes
+FROZEN_ENTITY_DESCRIPTION = MAJOR_VERSION >= 2024
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyEntityDescription(EntityDescription):
+    PLATFORM: Platform = None
+
+    sub_key: str | None = None
+    """用作 unique_id 的后缀。"""
+
+    unique_id_prefix: str | None = None
+    """用作 unique_id 的前缀。（目前只给scene用，考虑有没有更好的方式）"""
+
+    old_unique_id_suffix: str | None = None  # use for migrate
+
+    translation_key: str | None = None  # <2023.1 需要这一行，避免报错
+
+    required_attrs: list[str] | None = None
+    """需要的属性，如果没有这些属性，就不创建实体"""
+
+
+# region Binary Sensor
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyBinarySensorDescription(
+    TerncyEntityDescription, BinarySensorEntityDescription
+):
+    PLATFORM: Platform = Platform.BINARY_SENSOR
+    has_entity_name: bool = True
+    value_attr: str = ""
+    value_map: dict[int, bool] = field(
+        default_factory=lambda: {4: True, 3: True, 2: True, 1: True, 0: False}
+    )
+
+
+# endregion
+
+# region Climate
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyClimateDescription(TerncyEntityDescription, ClimateEntityDescription):
+    PLATFORM: Platform = Platform.CLIMATE
+    has_entity_name: bool = True
+    name: str | UndefinedType | None = None
+
+
+# endregion
+
+# region Cover
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyCoverDescription(TerncyEntityDescription, CoverEntityDescription):
+    PLATFORM: Platform = Platform.COVER
+    has_entity_name: bool = True
+    name: str | UndefinedType | None = None
+
+
+# endregion
+
+# region Event
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyEventDescription(TerncyEntityDescription, EventEntityDescription):
+    PLATFORM: Platform = Platform.EVENT
+    has_entity_name: bool = True
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyButtonDescription(TerncyEventDescription):
+    key: str = "event_button"
+    sub_key: str = "button"
+    device_class: EventDeviceClass = EventDeviceClass.BUTTON
+    translation_key: str = "button"
+    event_types: list[str] = field(
+        default_factory=lambda: list(EVENT_ENTITY_BUTTON_EVENTS)
+    )
+
+
+# endregion
+
+# region Light
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncyLightDescription(TerncyEntityDescription, LightEntityDescription):
+    key: str = "light"
+    PLATFORM: Platform = Platform.LIGHT
+    has_entity_name: bool = True
+    name: str | UndefinedType | None = None
+    color_mode: ColorMode | None = None
+    supported_color_modes: set[ColorMode] | None = None
+    supported_features: LightEntityFeature = 0
+
+
+# endregion
+
+# region Sensor
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncySensorDescription(TerncyEntityDescription, SensorEntityDescription):
+    PLATFORM: Platform = Platform.SENSOR
+    has_entity_name: bool = True
+    value_attr: str = ""
+    value_fn: Callable[[Any], StateType | date | datetime | Decimal] = lambda x: x
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TemperatureDescription(TerncySensorDescription):
+    key: str = "temperature"
+    sub_key: str = "temperature"
+    device_class: SensorDeviceClass = SensorDeviceClass.TEMPERATURE
+    native_unit_of_measurement: UnitOfTemperature = UnitOfTemperature.CELSIUS
+    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    suggested_display_precision: int = 1
+    value_attr: str = "temperature"
+    value_fn: Callable[[Any], StateType | date | datetime | Decimal] = (
+        lambda data: data / 10.0
+    )
+    old_unique_id_suffix: str = "_temptemp"
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class HumidityDescription(TerncySensorDescription):
+    key: str = "humidity"
+    sub_key: str = "humidity"
+    device_class: SensorDeviceClass = SensorDeviceClass.HUMIDITY
+    native_unit_of_measurement: str = PERCENTAGE
+    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    suggested_display_precision: int = 0
+    value_attr: str = "humidity"
+    old_unique_id_suffix: str = "_himidityhumidity"
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class IlluminanceDescription(TerncySensorDescription):
+    key: str = "illuminance"
+    sub_key: str = "illuminance"
+    device_class: SensorDeviceClass = SensorDeviceClass.ILLUMINANCE
+    native_unit_of_measurement: str = LIGHT_LUX
+    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    suggested_display_precision: int = 0
+    value_attr: str = "luminance"
+    old_unique_id_suffix: str = "_illu-illumin"
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class BatteryDescription(TerncySensorDescription):
+    key: str = "battery"
+    sub_key: str = "battery"
+    entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
+    device_class: SensorDeviceClass = SensorDeviceClass.BATTERY
+    native_unit_of_measurement: str = PERCENTAGE
+    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    suggested_display_precision: int = 0
+    value_attr: str = "battery"
+
+
+# endregion
+
+# region Switch
+
+
+@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+class TerncySwitchDescription(TerncyEntityDescription, SwitchEntityDescription):
+    PLATFORM: Platform = Platform.SWITCH
+    has_entity_name: bool = True
+    value_attr: str = "on"
+    invert_state: bool = False
+
+
+# endregion

--- a/custom_components/terncy/hub_monitor.py
+++ b/custom_components/terncy/hub_monitor.py
@@ -1,4 +1,5 @@
 """Hub monitor for the Terncy integration."""
+
 import ipaddress
 import logging
 import time

--- a/custom_components/terncy/hub_monitor.py
+++ b/custom_components/terncy/hub_monitor.py
@@ -50,7 +50,7 @@ class TerncyZCListener:
         if dev_id in self.manager.hubs:
             del self.manager.hubs[dev_id]
         txt_records = {CONF_DEVID: dev_id}
-        self.manager.hass.bus.async_fire(TERNCY_EVENT_SVC_REMOVE, txt_records)
+        self.manager.hass.bus.fire(TERNCY_EVENT_SVC_REMOVE, txt_records)
 
     def update_service(self, zconf, svc_type, name):
         """Get a terncy service updated event."""
@@ -62,7 +62,7 @@ class TerncyZCListener:
         txt_records = _parse_svc(dev_id, info)
 
         self.manager.hubs[dev_id] = txt_records
-        self.manager.hass.bus.async_fire(TERNCY_EVENT_SVC_UPDATE, txt_records)
+        self.manager.hass.bus.fire(TERNCY_EVENT_SVC_UPDATE, txt_records)
 
     def add_service(self, zconf, svc_type, name):
         """Get a new terncy service discovered event."""
@@ -85,7 +85,7 @@ class TerncyZCListener:
             info = zconf.get_service_info(svc_type, name)
 
         self.manager.hubs[dev_id] = txt_records
-        self.manager.hass.bus.async_fire(TERNCY_EVENT_SVC_ADD, txt_records)
+        self.manager.hass.bus.fire(TERNCY_EVENT_SVC_ADD, txt_records)
 
 
 class TerncyHubManager:

--- a/custom_components/terncy/profiles/before_2023_7.py
+++ b/custom_components/terncy/profiles/before_2023_7.py
@@ -17,8 +17,6 @@ from homeassistant.components.light import ColorMode
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.helpers.entity import EntityCategory  # <2023.3
 
-from ..binary_sensor import TerncyBinarySensorDescription
-from ..climate import TerncyClimateDescription
 from ..const import (
     PROFILE_AC_UNIT_MACHINE,
     PROFILE_COLOR_DIMMABLE_LIGHT,
@@ -44,15 +42,18 @@ from ..const import (
     PROFILE_SWITCH,
     PROFILE_XY_SINGLE_AIR_COND,
     PROFILE_YAN_BUTTON,
-    TerncyEntityDescription,
 )
-from ..cover import TerncyCoverDescription
-from ..light import TerncyLightDescription
-from ..sensor import (
+from ..hass.entity_descriptions import (
     BatteryDescription,
     HumidityDescription,
     IlluminanceDescription,
     TemperatureDescription,
+    TerncyBinarySensorDescription,
+    TerncyClimateDescription,
+    TerncyCoverDescription,
+    TerncyEntityDescription,
+    TerncyLightDescription,
+    TerncySwitchDescription,
 )
 from ..switch import (
     ATTR_DISABLED_RELAY_STATUS,
@@ -62,7 +63,6 @@ from ..switch import (
     KEY_DISABLED_RELAY_STATUS,
     KEY_DISABLE_RELAY,
     KEY_WALL_SWITCH,
-    TerncySwitchDescription,
 )
 
 PROFILES: dict[int, list[TerncyEntityDescription]] = {

--- a/custom_components/terncy/profiles/profiles.py
+++ b/custom_components/terncy/profiles/profiles.py
@@ -1,12 +1,11 @@
 """HA>=2023.7"""
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.light import ColorMode
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import EntityCategory
 
-from ..binary_sensor import TerncyBinarySensorDescription
-from ..climate import TerncyClimateDescription
 from ..const import (
     EVENT_ENTITY_BUTTON_EVENTS,
     EVENT_ENTITY_DIAL_EVENTS,
@@ -35,15 +34,19 @@ from ..const import (
     PROFILE_SWITCH,
     PROFILE_XY_SINGLE_AIR_COND,
     PROFILE_YAN_BUTTON,
-    TerncyEntityDescription,
 )
-from ..cover import TerncyCoverDescription
-from ..light import TerncyLightDescription
-from ..sensor import (
+from ..hass.entity_descriptions import (
     BatteryDescription,
     HumidityDescription,
     IlluminanceDescription,
     TemperatureDescription,
+    TerncyBinarySensorDescription,
+    TerncyButtonDescription,
+    TerncyClimateDescription,
+    TerncyCoverDescription,
+    TerncyEntityDescription,
+    TerncyLightDescription,
+    TerncySwitchDescription,
 )
 from ..switch import (
     ATTR_DISABLED_RELAY_STATUS,
@@ -53,7 +56,6 @@ from ..switch import (
     KEY_DISABLED_RELAY_STATUS,
     KEY_DISABLE_RELAY,
     KEY_WALL_SWITCH,
-    TerncySwitchDescription,
 )
 
 PROFILES: dict[int, list[TerncyEntityDescription]] = {
@@ -281,8 +283,6 @@ PROFILES: dict[int, list[TerncyEntityDescription]] = {
 }
 
 if HAS_EVENT_PLATFORM:
-    from ..event import TerncyButtonDescription
-
     EVENT_ENTITY_EVENTS_MAP = {
         PROFILE_PIR: EVENT_ENTITY_BUTTON_EVENTS,
         PROFILE_ONOFF_LIGHT: EVENT_ENTITY_BUTTON_EVENTS,

--- a/custom_components/terncy/sensor.py
+++ b/custom_components/terncy/sensor.py
@@ -1,108 +1,22 @@
 """Sensor platform support for Terncy."""
+
 import logging
-from dataclasses import dataclass
-from datetime import date, datetime
-from decimal import Decimal
-from typing import Any, Callable, TYPE_CHECKING
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    # EntityCategory,  # >=2023.3
-    LIGHT_LUX,
-    PERCENTAGE,
-    Platform,
-    UnitOfTemperature,
-)
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory  # <2023.3
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN, FROZEN_ENTITY_DESCRIPTION, TerncyEntityDescription
-from .core.entity import TerncyEntity, create_entity_setup
+from .hass.entity import TerncyEntity
+from .hass.entity_descriptions import TerncySensorDescription
 from .utils import get_attr_value
-
-if TYPE_CHECKING:
-    from .core.gateway import TerncyGateway
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class TerncySensorDescription(TerncyEntityDescription, SensorEntityDescription):
-    PLATFORM: Platform = Platform.SENSOR
-    has_entity_name: bool = True
-    value_attr: str = ""
-    value_fn: Callable[[Any], StateType | date | datetime | Decimal] = lambda x: x
-
-
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class TemperatureDescription(TerncySensorDescription):
-    key: str = "temperature"
-    sub_key: str = "temperature"
-    device_class: SensorDeviceClass = SensorDeviceClass.TEMPERATURE
-    native_unit_of_measurement: UnitOfTemperature = UnitOfTemperature.CELSIUS
-    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
-    suggested_display_precision: int = 1
-    value_attr: str = "temperature"
-    value_fn: Callable[[Any], StateType | date | datetime | Decimal] = (
-        lambda data: data / 10.0
-    )
-    old_unique_id_suffix: str = "_temptemp"
-
-
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class HumidityDescription(TerncySensorDescription):
-    key: str = "humidity"
-    sub_key: str = "humidity"
-    device_class: SensorDeviceClass = SensorDeviceClass.HUMIDITY
-    native_unit_of_measurement: str = PERCENTAGE
-    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
-    suggested_display_precision: int = 0
-    value_attr: str = "humidity"
-    old_unique_id_suffix: str = "_himidityhumidity"
-
-
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class IlluminanceDescription(TerncySensorDescription):
-    key: str = "illuminance"
-    sub_key: str = "illuminance"
-    device_class: SensorDeviceClass = SensorDeviceClass.ILLUMINANCE
-    native_unit_of_measurement: str = LIGHT_LUX
-    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
-    suggested_display_precision: int = 0
-    value_attr: str = "luminance"
-    old_unique_id_suffix: str = "_illu-illumin"
-
-
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class BatteryDescription(TerncySensorDescription):
-    key: str = "battery"
-    sub_key: str = "battery"
-    entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
-    device_class: SensorDeviceClass = SensorDeviceClass.BATTERY
-    native_unit_of_measurement: str = PERCENTAGE
-    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
-    suggested_display_precision: int = 0
-    value_attr: str = "battery"
-
-
 async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    hass, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    def new_entity(gateway, eid: str, description: TerncyEntityDescription):
-        return TerncySensor(gateway, eid, description)
-
-    gw: "TerncyGateway" = hass.data[DOMAIN][config_entry.entry_id]
-    gw.add_setup(Platform.SENSOR, create_entity_setup(async_add_entities, new_entity))
+    TerncyEntity.ADD[f"{entry.entry_id}.sensor"] = async_add_entities
 
 
 class TerncySensor(TerncyEntity, SensorEntity):
@@ -119,3 +33,6 @@ class TerncySensor(TerncyEntity, SensorEntity):
             self._attr_native_value = self.entity_description.value_fn(value)
         if self.hass:
             self.async_write_ha_state()
+
+
+TerncyEntity.NEW["sensor"] = TerncySensor


### PR DESCRIPTION
1. 还原了添加集成时自动生成的`entity_id`的命名风格。
Resolved #62 

2. 略微重构了一下添加实体到HA的逻辑，简化了一下代码。

3. 修复了一个 HA 2024.5 的 warning:
    > RuntimeError: Detected that custom integration 'terncy' calls async_fire from a thread at ......
---

> 这个PR应该对现有用户没有任何影响。
> 已在 HA 2024.4.4 和 2024.5.0b0 测试