### PR TITLE
Add support for tilt cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ terncy custome component for homeassistant
 ## Component Information
 
 - ha_iot_class: Local Push
-- ha_release: '2022.11.0'
+- ha_release: '2022.12.0'
 - ha_config_flow: true
 - ha_domain: terncy
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -10,7 +10,7 @@
 ## 插件信息
 
 - ha_iot_class: Local Push
-- home assistant 版本要求: '2022.11.0'
+- home assistant 版本要求: '2022.12.0'
 - ha_config_flow: true
 - ha_domain: terncy
 

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -526,15 +526,6 @@ class TerncyGateway:
                             or set(description.required_attrs).issubset(attrs)
                         )
                     ]
-                    descriptions = [
-                        description
-                        for description in descriptions
-                        if (
-                            not description.disabled_attrs
-                            or not set(description.disabled_attrs).issubset(attrs)
-                        )
-                    ]
-
                     if len(descriptions) > 0:
                         identifiers = {(DOMAIN, eid)}
                         device_registry.async_get_or_create(

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -575,7 +575,7 @@ class TerncyGateway:
         _LOGGER.debug("[%s] Fetching data...", self.unique_id)
 
         # room
-        lang = self.hass.config.language
+        lang = self.hass.config.language  # HA>=2022.12
         default_rooms = DEFAULT_ROOMS.get(lang, DEFAULT_ROOMS.get("en"))
         try:
             rooms: list[RoomData] = await self._fetch_data("room")

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -524,7 +524,7 @@ class TerncyGateway:
                     if svc_room := svc.get("room"):
                         if svc_room_name := self.room_data.get(svc_room):
                             suggested_area = svc_room_name
-                    attrs = [a['attr'] for a in attributes]
+                    attrs = [a["attr"] for a in attributes]
                     descriptions = [
                         description
                         for description in PROFILES.get(profile)
@@ -549,8 +549,10 @@ class TerncyGateway:
                         )
                         self.add_device(eid, device)
                         for description in descriptions:
-                            entity = create_entity(self, eid, description)
-                            entity._attr_device_info = DeviceInfo(identifiers=identifiers)
+                            entity = create_entity(self, eid, description, attributes)
+                            entity._attr_device_info = DeviceInfo(
+                                identifiers=identifiers
+                            )
                             ha_add_entity(self.hass, self.config_entry, entity)
                             device.entities.append(entity)
                 else:
@@ -638,6 +640,7 @@ class TerncyGateway:
         online = scene_data.get("online", True)
 
         entity = self.scenes.get(scene_id)
+        init_states = [{"attr": "on", "value": scene_data["on"]}]
         if not entity:
             description = TerncySwitchDescription(
                 key="scene",
@@ -646,7 +649,7 @@ class TerncyGateway:
                 unique_id_prefix=self.unique_id,  # scene_id不是uuid形式的，加个网关id作前缀
             )
             identifiers = {(DOMAIN, f"{self.unique_id}_scenes")}
-            entity = create_entity(self, scene_id, description)
+            entity = create_entity(self, scene_id, description, init_states)
             entity._attr_device_info = DeviceInfo(identifiers=identifiers)
             ha_add_entity(self.hass, self.config_entry, entity)
             self.scenes[scene_id] = entity
@@ -654,6 +657,6 @@ class TerncyGateway:
             entity._attr_name = name
 
         entity.set_available(online)
-        entity.update_state([{"attr": "on", "value": scene_data["on"]}])
+        entity.update_state(init_states)
 
     # endregion

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -11,15 +11,22 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
+    MAJOR_VERSION,
+    MINOR_VERSION,
 )
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     CONNECTION_ZIGBEE,
-    DeviceInfo,
     format_mac,
 )
+
+if (MAJOR_VERSION, MINOR_VERSION) >= (2023, 9):
+    from homeassistant.helpers.device_registry import DeviceInfo
+else:
+    from homeassistant.helpers.entity import DeviceInfo
+
 from homeassistant.helpers.typing import UNDEFINED
 from terncy import Terncy
 from terncy.event import Connected, Disconnected, EventMessage

--- a/custom_components/terncy/cover.py
+++ b/custom_components/terncy/cover.py
@@ -142,4 +142,3 @@ class TerncyTiltCover(TerncyCover):
 
 
 TerncyEntity.NEW["cover"] = TerncyCover
-TerncyEntity.NEW[f"cover.key.tilt"] = TerncyTiltCover

--- a/custom_components/terncy/hass/add_entities.py
+++ b/custom_components/terncy/hass/add_entities.py
@@ -8,6 +8,7 @@ from homeassistant.helpers import entity_registry as er
 from .entity import TerncyEntity
 from .entity_descriptions import TerncyEntityDescription
 from ..const import DOMAIN
+from ..types import AttrValue
 
 if TYPE_CHECKING:
     from ..core.gateway import TerncyGateway
@@ -19,13 +20,14 @@ def create_entity(
     gateway: "TerncyGateway",
     eid: str,
     description: TerncyEntityDescription,
+    init_states: list[AttrValue],  # 初始状态，用于判断设备支持多少特性。
 ) -> TerncyEntity:
     domain = str(description.PLATFORM)
     cls = (  # fmt: off
         TerncyEntity.NEW.get(f"{domain}.key.{description.key}")
         or TerncyEntity.NEW.get(domain)
     )
-    return cls(gateway, eid, description)
+    return cls(gateway, eid, description, init_states)
 
 
 def ha_add_entity(hass: HomeAssistant, config_entry: ConfigEntry, entity: TerncyEntity):

--- a/custom_components/terncy/hass/entity.py
+++ b/custom_components/terncy/hass/entity.py
@@ -22,7 +22,11 @@ class TerncyEntity(Entity):
 
     ADD: dict[str, AddEntitiesCallback] = {}  # key: config_entry_id.domain
     NEW: dict[
-        str, Callable[["TerncyGateway", str, TerncyEntityDescription], "TerncyEntity"]
+        str,
+        Callable[
+            ["TerncyGateway", str, TerncyEntityDescription, list[AttrValue]],
+            "TerncyEntity",
+        ],
     ] = {}  # key: domain.key or domain
 
     entity_description: TerncyEntityDescription
@@ -33,6 +37,7 @@ class TerncyEntity(Entity):
         gateway: "TerncyGateway",
         eid: str,
         description: TerncyEntityDescription,
+        init_states: list[AttrValue],
     ):
         self.gateway = gateway
         self.eid = eid

--- a/custom_components/terncy/hass/entity_descriptions.py
+++ b/custom_components/terncy/hass/entity_descriptions.py
@@ -6,7 +6,6 @@ from typing import Any, Callable
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 from homeassistant.components.climate import ClimateEntityDescription
 from homeassistant.components.cover import CoverEntityDescription
-from homeassistant.components.event import EventDeviceClass, EventEntityDescription
 from homeassistant.components.light import (
     ColorMode,
     LightEntityDescription,
@@ -19,18 +18,23 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.const import (
-    EntityCategory,
     LIGHT_LUX,
     MAJOR_VERSION,
+    MINOR_VERSION,
     PERCENTAGE,
     Platform,
     UnitOfTemperature,
 )
+
+if (MAJOR_VERSION, MINOR_VERSION) >= (2023, 3):
+    from homeassistant.const import EntityCategory
+else:
+    from homeassistant.helpers.entity import EntityCategory
+
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.typing import StateType, UndefinedType
 
-from ..const import EVENT_ENTITY_BUTTON_EVENTS
-
+from ..const import EVENT_ENTITY_BUTTON_EVENTS, HAS_EVENT_PLATFORM
 
 # https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes
 FROZEN_ENTITY_DESCRIPTION = MAJOR_VERSION >= 2024
@@ -97,20 +101,22 @@ class TerncyCoverDescription(TerncyEntityDescription, CoverEntityDescription):
 # region Event
 
 
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class TerncyEventDescription(TerncyEntityDescription, EventEntityDescription):
-    PLATFORM: Platform = Platform.EVENT
+if HAS_EVENT_PLATFORM:
+    from homeassistant.components.event import EventDeviceClass, EventEntityDescription
 
+    @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+    class TerncyEventDescription(TerncyEntityDescription, EventEntityDescription):
+        PLATFORM: Platform = Platform.EVENT
 
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class TerncyButtonDescription(TerncyEventDescription):
-    key: str = "event_button"
-    sub_key: str = "button"
-    device_class: EventDeviceClass = EventDeviceClass.BUTTON
-    translation_key: str = "button"
-    event_types: list[str] = field(
-        default_factory=lambda: list(EVENT_ENTITY_BUTTON_EVENTS)
-    )
+    @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
+    class TerncyButtonDescription(TerncyEventDescription):
+        key: str = "event_button"
+        sub_key: str = "button"
+        device_class: EventDeviceClass = EventDeviceClass.BUTTON
+        translation_key: str = "button"
+        event_types: list[str] = field(
+            default_factory=lambda: list(EVENT_ENTITY_BUTTON_EVENTS)
+        )
 
 
 # endregion

--- a/custom_components/terncy/hass/entity_descriptions.py
+++ b/custom_components/terncy/hass/entity_descriptions.py
@@ -40,6 +40,8 @@ FROZEN_ENTITY_DESCRIPTION = MAJOR_VERSION >= 2024
 class TerncyEntityDescription(EntityDescription):
     PLATFORM: Platform = None
 
+    has_entity_name: bool = True
+
     sub_key: str | None = None
     """用作 unique_id 的后缀。"""
 
@@ -62,7 +64,6 @@ class TerncyBinarySensorDescription(
     TerncyEntityDescription, BinarySensorEntityDescription
 ):
     PLATFORM: Platform = Platform.BINARY_SENSOR
-    has_entity_name: bool = True
     value_attr: str = ""
     value_map: dict[int, bool] = field(
         default_factory=lambda: {4: True, 3: True, 2: True, 1: True, 0: False}
@@ -77,7 +78,6 @@ class TerncyBinarySensorDescription(
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
 class TerncyClimateDescription(TerncyEntityDescription, ClimateEntityDescription):
     PLATFORM: Platform = Platform.CLIMATE
-    has_entity_name: bool = True
     name: str | UndefinedType | None = None
 
 
@@ -89,7 +89,6 @@ class TerncyClimateDescription(TerncyEntityDescription, ClimateEntityDescription
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
 class TerncyCoverDescription(TerncyEntityDescription, CoverEntityDescription):
     PLATFORM: Platform = Platform.COVER
-    has_entity_name: bool = True
     name: str | UndefinedType | None = None
 
 
@@ -101,7 +100,6 @@ class TerncyCoverDescription(TerncyEntityDescription, CoverEntityDescription):
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
 class TerncyEventDescription(TerncyEntityDescription, EventEntityDescription):
     PLATFORM: Platform = Platform.EVENT
-    has_entity_name: bool = True
 
 
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
@@ -124,7 +122,6 @@ class TerncyButtonDescription(TerncyEventDescription):
 class TerncyLightDescription(TerncyEntityDescription, LightEntityDescription):
     key: str = "light"
     PLATFORM: Platform = Platform.LIGHT
-    has_entity_name: bool = True
     name: str | UndefinedType | None = None
     color_mode: ColorMode | None = None
     supported_color_modes: set[ColorMode] | None = None
@@ -139,7 +136,6 @@ class TerncyLightDescription(TerncyEntityDescription, LightEntityDescription):
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
 class TerncySensorDescription(TerncyEntityDescription, SensorEntityDescription):
     PLATFORM: Platform = Platform.SENSOR
-    has_entity_name: bool = True
     value_attr: str = ""
     value_fn: Callable[[Any], StateType | date | datetime | Decimal] = lambda x: x
 
@@ -203,7 +199,6 @@ class BatteryDescription(TerncySensorDescription):
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
 class TerncySwitchDescription(TerncyEntityDescription, SwitchEntityDescription):
     PLATFORM: Platform = Platform.SWITCH
-    has_entity_name: bool = True
     value_attr: str = "on"
     invert_state: bool = False
 

--- a/custom_components/terncy/hass/entity_descriptions.py
+++ b/custom_components/terncy/hass/entity_descriptions.py
@@ -53,9 +53,6 @@ class TerncyEntityDescription(EntityDescription):
     required_attrs: list[str] | None = None
     """需要的属性，如果没有这些属性，就不创建实体"""
 
-    disabled_attrs: list[str] | None = None
-    """不应存在的属性，如果有任一属性，就不创建实体"""
-
 
 # region Binary Sensor
 
@@ -91,14 +88,6 @@ class TerncyClimateDescription(TerncyEntityDescription, ClimateEntityDescription
 
 @dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
 class TerncyCoverDescription(TerncyEntityDescription, CoverEntityDescription):
-    PLATFORM: Platform = Platform.COVER
-    has_entity_name: bool = True
-    name: str | UndefinedType | None = None
-
-
-@dataclass(frozen=FROZEN_ENTITY_DESCRIPTION, kw_only=True)
-class TerncyTiltCoverDescription(TerncyEntityDescription, CoverEntityDescription):
-    key: str = "tilt"
     PLATFORM: Platform = Platform.COVER
     has_entity_name: bool = True
     name: str | UndefinedType | None = None

--- a/custom_components/terncy/light.py
+++ b/custom_components/terncy/light.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .hass.entity import TerncyEntity
 from .hass.entity_descriptions import TerncyLightDescription
+from .types import AttrValue
 from .utils import get_attr_value
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,8 +42,14 @@ class TerncyLight(TerncyEntity, LightEntity):
     _attr_supported_color_modes: set[ColorMode] | set[str] | None
     _attr_supported_features: LightEntityFeature
 
-    def __init__(self, gateway, eid: str, description: TerncyLightDescription):
-        super().__init__(gateway, eid, description)
+    def __init__(
+        self,
+        gateway,
+        eid: str,
+        description: TerncyLightDescription,
+        init_states: list[AttrValue],
+    ):
+        super().__init__(gateway, eid, description, init_states)
         self._attr_brightness = 0
         self._attr_color_mode = description.color_mode
         self._attr_color_temp = 0

--- a/custom_components/terncy/profiles/before_2023_7.py
+++ b/custom_components/terncy/profiles/before_2023_7.py
@@ -64,9 +64,6 @@ from ..switch import (
     KEY_DISABLE_RELAY,
     KEY_WALL_SWITCH,
 )
-from ..cover import (
-    ATTR_TILT_POSITION,
-)
 
 PROFILES: dict[int, list[TerncyEntityDescription]] = {
     PROFILE_PIR: [
@@ -155,12 +152,6 @@ PROFILES: dict[int, list[TerncyEntityDescription]] = {
         TerncyCoverDescription(
             key="cover",
             device_class=CoverDeviceClass.CURTAIN,
-            disabled_attrs = [ATTR_TILT_POSITION],
-        ),
-        TerncyCoverDescription(
-            key="cover",
-            device_class=CoverDeviceClass.CURTAIN,
-            required_attrs = [ATTR_TILT_POSITION],
         ),
     ],
     PROFILE_YAN_BUTTON: [

--- a/custom_components/terncy/profiles/before_2023_7.py
+++ b/custom_components/terncy/profiles/before_2023_7.py
@@ -15,7 +15,12 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.light import ColorMode
 from homeassistant.components.switch import SwitchDeviceClass
-from homeassistant.helpers.entity import EntityCategory  # <2023.3
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+
+if (MAJOR_VERSION, MINOR_VERSION) >= (2023, 3):
+    from homeassistant.const import EntityCategory
+else:
+    from homeassistant.helpers.entity import EntityCategory
 
 from ..const import (
     PROFILE_AC_UNIT_MACHINE,

--- a/custom_components/terncy/profiles/profiles.py
+++ b/custom_components/terncy/profiles/profiles.py
@@ -57,9 +57,6 @@ from ..switch import (
     KEY_DISABLE_RELAY,
     KEY_WALL_SWITCH,
 )
-from ..cover import (
-    ATTR_TILT_POSITION,
-)
 
 PROFILES: dict[int, list[TerncyEntityDescription]] = {
     PROFILE_PIR: [
@@ -150,12 +147,6 @@ PROFILES: dict[int, list[TerncyEntityDescription]] = {
         TerncyCoverDescription(
             key="cover",
             device_class=CoverDeviceClass.CURTAIN,
-            disabled_attrs = [ATTR_TILT_POSITION],
-        ),
-        TerncyCoverDescription(
-            key="cover",
-            device_class=CoverDeviceClass.CURTAIN,
-            required_attrs = [ATTR_TILT_POSITION],
         ),
     ],
     PROFILE_YAN_BUTTON: [

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Terncy",
   "render_readme": true,
-  "homeassistant": "2022.11.0"
+  "homeassistant": "2022.12.0"
 }


### PR DESCRIPTION
添加了梦幻帘的旋转角度支持，字段 `tilt_angle` 值在 -90~90 范围内的窗帘设备会视作支持旋转操作。

不过由于HA这边只有0~100对应关到开，所以暂时并不支持左旋和右旋两种关闭方式，目前关闭的时候默认朝最近的方向去关。

---

另外更新了HA最低版本要求到 2022.12。（之前的2022.11是标注错误，实际并不能运行）