### PR TITLE
Fix retry when reload entry

### DIFF
--- a/custom_components/terncy/__init__.py
+++ b/custom_components/terncy/__init__.py
@@ -75,6 +75,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         if gateway := hass.data[DOMAIN].get(entry.entry_id):
+            gateway.api.retry = False
             await gateway.api.stop()
             hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/terncy/const.py
+++ b/custom_components/terncy/const.py
@@ -11,7 +11,6 @@ TERNCY_MANU_NAME = "Xiaoyan Tech."
 
 TERNCY_EVENT_SVC_ADD = "terncy_svc_add"
 TERNCY_EVENT_SVC_REMOVE = "terncy_svc_remove"
-TERNCY_EVENT_SVC_RECONNECT = "terncy_svc_reconnect"
 TERNCY_EVENT_SVC_UPDATE = "terncy_svc_update"
 
 PROFILE_PIR = 0

--- a/custom_components/terncy/core/device.py
+++ b/custom_components/terncy/core/device.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
@@ -6,8 +5,6 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF
 from ..const import DEVICE_TRIGGER_ACTIONS_MAP, DOMAIN, HAS_EVENT_PLATFORM
 from ..hass.entity import TerncyEntity
 from ..types import AttrValue
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class TerncyDevice:

--- a/custom_components/terncy/core/gateway.py
+++ b/custom_components/terncy/core/gateway.py
@@ -48,7 +48,6 @@ from ..const import (
     EVENT_ENTITY_BUTTON_EVENTS,
     HA_CLIENT_ID,
     TERNCY_EVENT_SVC_ADD,
-    TERNCY_EVENT_SVC_RECONNECT,
     TERNCY_EVENT_SVC_REMOVE,
     TERNCY_HUB_ID_PREFIX,
     TERNCY_MANU_NAME,
@@ -73,8 +72,6 @@ from ..types import (
     SvcData,
 )
 
-_LOGGER = logging.getLogger(__name__)
-
 SetupHandler = Callable[
     [
         ForwardRef("TerncyGateway"),
@@ -94,6 +91,8 @@ class TerncyGateway:
         self.hass = hass
         self.config_entry = config_entry
 
+        self._stopped = False
+
         self.parsed_devices: dict[str, TerncyDevice] = {}  # key: eid
         self._listeners: dict[str, set[Callable[[list[AttrValue]], None]]] = {}
         self.room_data: dict[str, str] = {}  # room_id: room_name
@@ -101,14 +100,16 @@ class TerncyGateway:
 
         self.name = config_entry.title
         self.mac = format_mac(config_entry.unique_id.replace(TERNCY_HUB_ID_PREFIX, ""))
+        ip = config_entry.data[CONF_HOST]
         self.api = Terncy(
             HA_CLIENT_ID,
             config_entry.data["identifier"],
-            config_entry.data[CONF_HOST],
+            ip,
             config_entry.data[CONF_PORT],
             config_entry.data[CONF_USERNAME],
             config_entry.data[CONF_TOKEN],
         )
+        self.logger = logging.getLogger(f"{__name__}.{ip}")
 
         # region 配置项
         self.export_device_groups = config_entry.options.get(
@@ -120,17 +121,14 @@ class TerncyGateway:
 
         async def on_hass_stop(event: Event):
             """Stop push updates when hass stops."""
-            _LOGGER.debug("STOP %s", self.unique_id)
-            await self.api.stop()
+            self.logger.debug("on_hass_stop")
+            await self.stop()
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
 
     def start(self):
         tern = self.api
-        tern.retry = True
-
-        async def setup_terncy_loop():
-            asyncio.create_task(tern.start())
+        self._stopped = False
 
         def on_terncy_svc_add(event: Event):
             """Terncy service found handler"""
@@ -138,40 +136,19 @@ class TerncyGateway:
             if dev_id != tern.dev_id:
                 return
 
-            _LOGGER.debug("Found terncy service: %s %s", dev_id, event.data)
+            self.logger.debug("Found terncy service: %s %s", dev_id, event.data)
             ip = event.data[CONF_IP]
             if ip == "":
-                _LOGGER.warning("dev %s's ip address is not valid", dev_id)
+                self.logger.warning(
+                    "dev %s's ip address is not valid. %s", dev_id, event.data
+                )
                 return
             if not tern.is_connected():
                 tern.ip = ip
-                _LOGGER.debug("Start connecting %s %s", dev_id, tern.ip)
-                tern.retry = True
-                self.async_create_task(setup_terncy_loop())
-
-        async def on_terncy_svc_reconnect(event: Event):
-            """Terncy service retry connection handler"""
-            dev_id = event.data[CONF_DEVID]
-            if dev_id != tern.dev_id:
-                return
-            if not tern.retry:
-                _LOGGER.warning("service %s %s stopped, don't retry", dev_id, tern.ip)
-                return
-
-            _LOGGER.warning(
-                "Reconnect terncy service: %s %s to wait", dev_id, event.data
-            )
-            await asyncio.sleep(2)
-            _LOGGER.warning(
-                "Reconnect terncy service: %s %s after wait", dev_id, event.data
-            )
-            if not tern.is_connected():
-                _LOGGER.warning("Start connecting %s %s", dev_id, tern.ip)
-                self.async_create_task(setup_terncy_loop())
-            else:
-                _LOGGER.warning(
-                    "service %s %s is still connected while retry", dev_id, event.data
-                )
+                self.logger = logging.getLogger(f"{__name__}.{ip}")
+                self.logger.debug("Start connecting %s", dev_id)
+                self._stopped = False
+                self.async_create_background_task(self.api.start(), "Start")
 
         def on_terncy_svc_remove(event: Event):
             """Terncy service stop handler"""
@@ -179,23 +156,37 @@ class TerncyGateway:
             if dev_id != tern.dev_id:
                 return
 
-            _LOGGER.debug("on_terncy_svc_remove %s", event.data[CONF_DEVID])
-            self.async_create_task(tern.stop())
-            tern.retry = False
+            self.logger.debug("on_terncy_svc_remove %s", event.data[CONF_DEVID])
+            self.async_create_task(self.stop())
 
         self.hass.bus.async_listen(TERNCY_EVENT_SVC_ADD, on_terncy_svc_add)
-        self.hass.bus.async_listen(TERNCY_EVENT_SVC_RECONNECT, on_terncy_svc_reconnect)
         self.hass.bus.async_listen(TERNCY_EVENT_SVC_REMOVE, on_terncy_svc_remove)
 
         hub_manager = TerncyHubManager.instance(self.hass)
-        if (
-            txt_records := hub_manager.hubs.get(tern.dev_id)
-        ) and not tern.is_connected():
+        if (txt_records := hub_manager.hubs.get(tern.dev_id)) and not self.is_connected:
             tern.ip = txt_records[CONF_IP]
-            _LOGGER.debug("Start connection to %s %s", tern.dev_id, tern.ip)
-            self.async_create_task(setup_terncy_loop())
+            self.logger.debug("Start connection to %s", tern.dev_id)
+            self.async_create_background_task(self.api.start(), "Start")
 
         tern.register_event_handler(self.terncy_event_handler)
+
+    async def stop(self):
+        self._stopped = True
+        await self.api.stop()
+
+    async def reconnect(self):
+        """Terncy service retry connection handler"""
+        if self._stopped:
+            self.logger.debug("service stopped, don't retry")
+            return
+
+        await asyncio.sleep(2)
+        if self.is_connected:
+            self.logger.warning("service is still connected while retry")
+            return
+
+        self.logger.warning("Start reconnecting...")
+        await self.api.start()
 
     @property
     def unique_id(self):
@@ -210,22 +201,22 @@ class TerncyGateway:
     ) -> CALLBACK_TYPE:
         @callback
         def remove_listener() -> None:
-            # _LOGGER.debug("[%s] remove_listener %s", self.unique_id, eid)
+            # self.logger.debug("remove_listener %s", eid)
             if eid in self._listeners:
                 self._listeners[eid].discard(listener)
 
-        # _LOGGER.debug("[%s] add_listener %s", self.unique_id, eid)
+        # self.logger.debug("add_listener %s", eid)
         self._listeners.setdefault(eid, set()).add(listener)
 
         return remove_listener
 
     def update_listeners(self, eid: str, data: list[AttrValue]):
-        # _LOGGER.debug("[%s] STATE: %s <= %s", self.unique_id, eid, data)
+        # self.logger.debug("STATE: %s <= %s", eid, data)
         if eid in self._listeners:
             for listener in self._listeners[eid]:
                 listener(data)
         # else:
-        #     _LOGGER.debug("[%s] no listener for %s", self.unique_id, eid)
+        #     self.logger.debug("no listener for %s", eid)
 
     async def set_attribute(self, eid: str, attr: str, value, method=0):
         await self.api.set_attribute(eid, attr, value, method)
@@ -242,9 +233,9 @@ class TerncyGateway:
 
         if isinstance(event, EventMessage):
             msg = event.msg
-            # _LOGGER.debug("[%s] EventMessage: %s", gateway.unique_id, msg)
+            # self.logger.debug("EventMessage: %s", msg)
             if "entities" not in msg:
-                _LOGGER.warning("'entities' not found in message!")
+                self.logger.warning("'entities' not found in message!")
                 return
 
             msg_data = msg.get("entities", [])
@@ -268,40 +259,37 @@ class TerncyGateway:
             elif event_type == "offline":
                 self._on_offline(msg_data)
             elif event_type is None:
-                _LOGGER.debug(
-                    "[%s] event type is None, ignore. %s", self.unique_id, msg
-                )
+                self.logger.debug("event type is None, ignore. %s", msg)
             else:
-                _LOGGER.warning(
-                    "[%s] unsupported event type: %s, entities: %s",
-                    self.unique_id,
+                self.logger.warning(
+                    "unsupported event type: %s, entities: %s",
                     event_type,
                     msg_data,
                 )
 
         elif isinstance(event, Connected):
-            _LOGGER.info("[%s] Connected.", api.dev_id)
+            self.logger.info("Connected: %s", self.unique_id)
             self.async_create_task(self.async_refresh_devices())
 
         elif isinstance(event, Disconnected):
-            _LOGGER.warning("[%s] Disconnected.", api.dev_id)
+            self.logger.warning("Disconnected: %s", self.unique_id)
             for device in self.parsed_devices.values():
                 device.set_available(False)
-            txt_records = {CONF_DEVID: api.dev_id}
-            self.hass.bus.async_fire(TERNCY_EVENT_SVC_RECONNECT, txt_records)
+            if not self._stopped:
+                self.async_create_background_task(self.reconnect(), "Reconnect")
 
         else:
-            _LOGGER.warning("[%s] Unknown Event: %s", self.unique_id, event)
+            self.logger.warning("Unknown Event: %s", event)
 
     def _on_report(self, msg_data: ReportMsgData):
-        _LOGGER.debug("[%s] EVENT: report: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: report: %s", msg_data)
         for id_attributes in msg_data:
             eid = id_attributes.get("id")
             attributes = id_attributes.get("attributes", [])
             self.update_listeners(eid, attributes)
 
     def _on_key_pressed(self, msg_data: KeyPressedMsgData):
-        _LOGGER.debug("[%s] EVENT: keyPressed: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: keyPressed: %s", msg_data)
         device_registry = dr.async_get(self.hass)
         for entity_data in msg_data:
             if "attributes" not in entity_data:
@@ -328,7 +316,7 @@ class TerncyGateway:
                 )
 
     def _on_key_long_pressed(self, msg_data: SimpleMsgData):
-        _LOGGER.debug("[%s] EVENT: keyLongPressed: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: keyLongPressed: %s", msg_data)
         device_registry = dr.async_get(self.hass)
         for item in msg_data:
             eid = item["id"]
@@ -346,7 +334,7 @@ class TerncyGateway:
                 )
 
     def _on_rotation(self, msg_data: SimpleMsgData):
-        _LOGGER.debug("[%s] EVENT: rotation: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: rotation: %s", msg_data)
         device_registry = dr.async_get(self.hass)
         for item in msg_data:
             eid = item["id"]
@@ -364,7 +352,7 @@ class TerncyGateway:
                 )
 
     def _on_entity_available(self, msg_data: EntityAvailableMsgData):
-        _LOGGER.debug("[%s] EVENT: entityAvailable: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: entityAvailable: %s", msg_data)
         for device_data in msg_data:
             if device_data["type"] == "device":
                 svc_list = device_data.get("services", [])
@@ -373,14 +361,12 @@ class TerncyGateway:
                 # do nothing
                 pass
             else:
-                _LOGGER.warning(
-                    "[%s] entityAvailable: **UNSUPPORTED TYPE**: %s",
-                    self.unique_id,
-                    device_data,
+                self.logger.warning(
+                    "entityAvailable: **UNSUPPORTED TYPE**: %s", device_data
                 )
 
     def _on_entity_deleted(self, msg_data: SimpleMsgData):
-        _LOGGER.debug("[%s] EVENT: entityDeleted: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: entityDeleted: %s", msg_data)
         device_registry = dr.async_get(self.hass)
         for item in msg_data:
             did = item["id"]  # did or scene_id
@@ -401,44 +387,41 @@ class TerncyGateway:
                         identifiers={(DOMAIN, eid)}
                     ):
                         device_registry.async_remove_device(device_entry.id)
-                        _LOGGER.debug(
-                            "[%s] removed device_entry: %s %s",
-                            self.unique_id,
+                        self.logger.debug(
+                            "removed device_entry: %s %s",
                             device_entry.id,
                             device_entry.name,
                         )
                     self.parsed_devices.pop(eid)
 
     def _on_entity_updated(self, msg_data: EntityUpdatedMsgData):
-        _LOGGER.debug("[%s] EVENT: entityUpdated: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: entityUpdated: %s", msg_data)
         for item in msg_data:
             if item["type"] == "scene":
                 self.setup_scene(item)
             elif item["type"] == "user":
-                _LOGGER.debug("[%s] type user, ignore.", self.unique_id)
+                self.logger.debug("type user, ignore.")
             else:
-                _LOGGER.info(
-                    "[%s] entityUpdated: **UNSUPPORTED TYPE**: %s",
-                    self.unique_id,
+                self.logger.info(
+                    "entityUpdated: **UNSUPPORTED TYPE**: %s",
                     item,
                 )
 
     def _on_entity_created(self, msg_data: EntityCreatedMsgData):
-        _LOGGER.debug("[%s] EVENT: entityCreated: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: entityCreated: %s", msg_data)
         for item in msg_data:
             if item["type"] == "scene":
                 self.setup_scene(item)
             elif item["type"] == "devicegroup":
                 self.setup_device_group(item)
             else:
-                _LOGGER.debug(
-                    "[%s] entityCreated: **UNSUPPORTED TYPE**: %s",
-                    self.unique_id,
+                self.logger.debug(
+                    "entityCreated: **UNSUPPORTED TYPE**: %s",
                     item,
                 )
 
     def _on_offline(self, msg_data: SimpleMsgData):
-        _LOGGER.debug("[%s] EVENT: offline: %s", self.unique_id, msg_data)
+        self.logger.debug("EVENT: offline: %s", msg_data)
         for device_data in msg_data:
             did = device_data["id"]
             for device in self.parsed_devices.values():
@@ -452,6 +435,15 @@ class TerncyGateway:
     @callback
     def async_create_task(self, target: Coroutine):
         return self.config_entry.async_create_task(self.hass, target)
+
+    @callback
+    def async_create_background_task(self, target: Coroutine, name: str):
+        if (MAJOR_VERSION, MINOR_VERSION) >= (2023, 3):
+            return self.config_entry.async_create_background_task(
+                self.hass, target, name
+            )
+        else:
+            return asyncio.create_task(target)
 
     # endregion
 
@@ -468,7 +460,7 @@ class TerncyGateway:
         """Got device data, create devices if not exist or update states."""
 
         model = device_data.get("model")
-        _LOGGER.debug("[%s] setup %s: %s", self.unique_id, model, svc_list)
+        self.logger.debug("setup %s: %s", model, svc_list)
 
         did = device_data["id"]
         sw_version = (
@@ -515,7 +507,7 @@ class TerncyGateway:
 
             device = self.parsed_devices.get(eid)
             if not device:
-                # _LOGGER.debug("[%s] New device: %s %s", self.unique_id, did, eid)
+                # self.logger.debug("New device: %s %s", did, eid)
 
                 profile = svc.get("profile")
                 device = TerncyDevice(did, eid, profile)
@@ -556,7 +548,7 @@ class TerncyGateway:
                             ha_add_entity(self.hass, self.config_entry, entity)
                             device.entities.append(entity)
                 else:
-                    _LOGGER.debug(
+                    self.logger.debug(
                         "[%s] Unsupported profile:%d %s", eid, profile, attributes
                     )
 
@@ -567,12 +559,12 @@ class TerncyGateway:
     async def _fetch_data(self, ent_type: str) -> list:
         response = await self.api.get_entities(ent_type, True)
         if "rsp" not in response:
-            _LOGGER.warning("fetch %s error, response: %s", ent_type, response)
+            self.logger.warning("fetch %s error, response: %s", ent_type, response)
         return response.get("rsp", {}).get("entities", [])
 
     async def async_refresh_devices(self):
         """Get devices from terncy."""
-        _LOGGER.debug("[%s] Fetching data...", self.unique_id)
+        self.logger.debug("Fetching data...")
 
         # room
         lang = self.hass.config.language  # HA>=2022.12
@@ -583,13 +575,13 @@ class TerncyGateway:
                 room["id"]: room["name"] or default_rooms.get(room["id"], "")
                 for room in rooms
             }
-            _LOGGER.debug("[%s] ROOM %s: %s", self.unique_id, lang, self.room_data)
+            self.logger.debug("ROOM %s: %s", lang, self.room_data)
         except Exception as e:
-            _LOGGER.warning("fetch room error: %s", e)
+            self.logger.warning("fetch room error: %s", e)
 
         # device
         devices: list[PhysicalDeviceData] = await self._fetch_data("device")
-        # _LOGGER.debug("[%s] got devices %s", self.unique_id, devices)
+        # self.logger.debug("got devices %s", devices)
 
         for device_data in devices:
             svc_list = device_data.get("services", [])
@@ -597,7 +589,7 @@ class TerncyGateway:
 
         # device group
         device_groups: list[DeviceGroupData] = await self._fetch_data("devicegroup")
-        # _LOGGER.debug("[%s] got device_groups %s", self.unique_id, device_groups)
+        # self.logger.debug("got device_groups %s", device_groups)
 
         if self.export_device_groups:
             for device_group_data in device_groups:
@@ -605,7 +597,7 @@ class TerncyGateway:
 
         # scene
         scenes: list[SceneData] = await self._fetch_data("scene")
-        _LOGGER.debug("[%s] SCENE: %s", self.unique_id, scenes)
+        self.logger.debug("SCENE: %s", scenes)
 
         if self.export_scenes:
             # 创建一个共用的设备，里面放所有的场景开关
@@ -634,7 +626,7 @@ class TerncyGateway:
                 entity.set_available(False)
             return
 
-        _LOGGER.debug("[%s] setup %s %s", self.unique_id, scene_id, scene_data)
+        self.logger.debug("setup %s %s", scene_id, scene_data)
 
         name = scene_data.get("name") or scene_id  # some name is ""
         online = scene_data.get("online", True)

--- a/custom_components/terncy/hass/add_entities.py
+++ b/custom_components/terncy/hass/add_entities.py
@@ -1,4 +1,3 @@
-import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
@@ -12,8 +11,6 @@ from ..types import AttrValue
 
 if TYPE_CHECKING:
     from ..core.gateway import TerncyGateway
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def create_entity(
@@ -35,15 +32,15 @@ def ha_add_entity(hass: HomeAssistant, config_entry: ConfigEntry, entity: Terncy
     domain = str(entity.entity_description.PLATFORM)
     config_entry_id = config_entry.entry_id
     registry = er.async_get(hass)
+    gateway = entity.gateway
     if entity_id := registry.async_get_entity_id(domain, DOMAIN, entity.unique_id):
         if entity_entry := registry.async_get(entity_id):
             if entity_entry.config_entry_id != config_entry_id:
-                _LOGGER.debug(
-                    "[%s] entity %s already exists, skip",
-                    entity.gateway.unique_id,
+                gateway.logger.debug(
+                    "entity %s already exists, skip",
                     entity.unique_id,
                 )
                 return
-    _LOGGER.debug("[%s] created entity %s", entity.gateway.unique_id, entity.unique_id)
+    gateway.logger.debug("created entity %s", entity.unique_id)
     async_add_entities = TerncyEntity.ADD[f"{config_entry_id}.{domain}"]
     async_add_entities([entity], update_before_add=False)

--- a/custom_components/terncy/hass/entity.py
+++ b/custom_components/terncy/hass/entity.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -12,9 +11,6 @@ from ..types import AttrValue
 
 if TYPE_CHECKING:
     from ..core.gateway import TerncyGateway
-
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class TerncyEntity(Entity):
@@ -81,7 +77,7 @@ class TerncyEntity(Entity):
             DOMAIN,
             f"{self.eid}{description.old_unique_id_suffix}",
         ):
-            _LOGGER.debug("Migrate from old entity_id %s", old_entity_id)
+            self.gateway.logger.debug("Migrate from old entity_id %s", old_entity_id)
             entity_registry.async_update_entity(
                 old_entity_id,
                 new_unique_id=self._attr_unique_id,


### PR DESCRIPTION
之前，重载集成的时候，没有把 `retry` 设成 `False`，会导致旧的实例自动重连并且依然留在那里。
打开调试日志 重载集成 就可以很容易观察到后续日志都会有两份，再重载一次就会变成三份。。。

这里修复了这个问题，顺便调整了一下日志和重连的代码。