### PR TITLE
use `LightEntityFeature(0)` instead of `0`

### DIFF
--- a/custom_components/terncy/hass/entity_descriptions.py
+++ b/custom_components/terncy/hass/entity_descriptions.py
@@ -131,7 +131,7 @@ class TerncyLightDescription(TerncyEntityDescription, LightEntityDescription):
     name: str | UndefinedType | None = None
     color_mode: ColorMode | None = None
     supported_color_modes: set[ColorMode] | None = None
-    supported_features: LightEntityFeature = 0
+    supported_features: LightEntityFeature = LightEntityFeature(0)
 
 
 # endregion


### PR DESCRIPTION
fix warning in HA 2024.11.0

https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/