### PR TITLE
Relocate zeroconf ServiceInfo models

### DIFF
--- a/custom_components/terncy/config_flow.py
+++ b/custom_components/terncy/config_flow.py
@@ -7,7 +7,6 @@ from typing import Any
 import terncy
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.const import CONF_DEVICE, CONF_PORT, MAJOR_VERSION, MINOR_VERSION
 from homeassistant.core import callback
@@ -22,6 +21,11 @@ from .const import (
     TERNCY_HUB_SVC_NAME,
 )
 from .hub_monitor import TerncyHubManager
+
+if (MAJOR_VERSION, MINOR_VERSION) >= (2025, 2):
+    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+else:
+    from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
fix warning in HA 2025.2.0

    2025-02-06 23:03:52.708 WARNING (ImportExecutor_0) [homeassistant.components.zeroconf] ZeroconfServiceInfo was used from terncy, this is a deprecated constant which will be removed in HA Core 2026.2. Use homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo instead, please report it to the author of the 'terncy' custom integration

https://developers.home-assistant.io/blog/2025/01/15/service-info