### PR TITLE
feat: add single_press and some other entity

### DIFF
--- a/custom_components/terncy/core/device.py
+++ b/custom_components/terncy/core/device.py
@@ -54,5 +54,5 @@ class TerncyDevice:
             from ..event import TerncyEvent
 
             for entity in self.entities:
-                if isinstance(entity, TerncyEvent):
+                if isinstance(entity, TerncyEvent) and event_type in entity.event_types:
                     entity.trigger_event(event_type, event_attributes)

--- a/custom_components/terncy/core/device.py
+++ b/custom_components/terncy/core/device.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, Callable
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import CALLBACK_TYPE, callback
 
-from ..const import DEVICE_TRIGGER_ACTIONS_MAP, DOMAIN, HAS_EVENT_PLATFORM
+from ..const import DEVICE_TRIGGER_ACTIONS_MAP, DOMAIN
 from ..hass.entity import TerncyEntity
 from ..types import AttrValue
 
@@ -23,6 +24,9 @@ class TerncyDevice:
         self.eid = eid  # -01 -02 ... 结尾的
         self.profile = profile
         self.entities: list[TerncyEntity] = []
+        self._listeners: dict[
+            str, set[Callable[[str, dict[str, Any] | None], None]]
+        ] = {}
 
         # self.identifiers = {(DOMAIN, eid)}
 
@@ -49,10 +53,21 @@ class TerncyDevice:
 
     def trigger_event(
         self, event_type: str, event_attributes: dict[str, Any] | None = None
-    ):
-        if HAS_EVENT_PLATFORM:
-            from ..event import TerncyEvent
+    ) -> None:
+        if event_type in self._listeners:
+            for trigger_event in self._listeners[event_type]:
+                trigger_event(event_type, event_attributes)
 
-            for entity in self.entities:
-                if isinstance(entity, TerncyEvent) and event_type in entity.event_types:
-                    entity.trigger_event(event_type, event_attributes)
+    def add_event_listener(
+        self,
+        event_type: str,
+        trigger_event: Callable[[str, dict[str, Any] | None], None],
+    ) -> CALLBACK_TYPE:
+        @callback
+        def remove_listener() -> None:
+            if event_type in self._listeners:
+                self._listeners[event_type].discard(trigger_event)
+
+        self._listeners.setdefault(event_type, set()).add(trigger_event)
+
+        return remove_listener

--- a/custom_components/terncy/event.py
+++ b/custom_components/terncy/event.py
@@ -24,6 +24,14 @@ class TerncyEvent(TerncyEntity, EventEntity):
 
     entity_description: TerncyEventDescription
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if device := self.gateway.parsed_devices.get(self.eid):
+            for event_type in self.event_types:
+                self.async_on_remove(
+                    device.add_event_listener(event_type, self.trigger_event)
+                )
+
     def update_state(self, attrs):
         # _LOGGER.debug("%s <= %s", self.eid, attrs)
         # do nothing

--- a/custom_components/terncy/profiles/profiles.py
+++ b/custom_components/terncy/profiles/profiles.py
@@ -45,7 +45,6 @@ from ..hass.entity_descriptions import (
     IlluminanceDescription,
     TemperatureDescription,
     TerncyBinarySensorDescription,
-    TerncyButtonDescription,
     TerncyClimateDescription,
     TerncyCoverDescription,
     TerncyEntityDescription,
@@ -287,6 +286,8 @@ PROFILES: dict[int, list[TerncyEntityDescription]] = {
 }
 
 if HAS_EVENT_PLATFORM:
+    from ..hass.entity_descriptions import TerncyButtonDescription
+
     EVENT_ENTITY_EVENTS_MAP = {
         PROFILE_PIR: EVENT_ENTITY_BUTTON_EVENTS,
         PROFILE_ONOFF_LIGHT: EVENT_ENTITY_BUTTON_EVENTS,

--- a/custom_components/terncy/profiles/profiles.py
+++ b/custom_components/terncy/profiles/profiles.py
@@ -7,6 +7,10 @@ from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import EntityCategory
 
 from ..const import (
+    ACTION_DOUBLE_PRESS,
+    ACTION_LONG_PRESS,
+    ACTION_ROTATION,
+    ACTION_SINGLE_PRESS,
     EVENT_ENTITY_BUTTON_EVENTS,
     EVENT_ENTITY_DIAL_EVENTS,
     HAS_EVENT_PLATFORM,
@@ -290,8 +294,46 @@ if HAS_EVENT_PLATFORM:
         PROFILE_YAN_BUTTON: EVENT_ENTITY_BUTTON_EVENTS,
         PROFILE_SMART_DIAL: EVENT_ENTITY_DIAL_EVENTS,
     }
+
+    SINGLE = TerncyButtonDescription(
+        key=ACTION_SINGLE_PRESS,
+        sub_key=ACTION_SINGLE_PRESS,
+        translation_key=ACTION_SINGLE_PRESS,
+        event_types=[ACTION_SINGLE_PRESS],
+    )
+    DOUBLE = TerncyButtonDescription(
+        key=ACTION_DOUBLE_PRESS,
+        sub_key=ACTION_DOUBLE_PRESS,
+        translation_key=ACTION_DOUBLE_PRESS,
+        event_types=[ACTION_DOUBLE_PRESS],
+        entity_registry_enabled_default=False,  # 双击默认禁用
+    )
+    LONG = TerncyButtonDescription(
+        key=ACTION_LONG_PRESS,
+        sub_key=ACTION_LONG_PRESS,
+        translation_key=ACTION_LONG_PRESS,
+        event_types=[ACTION_LONG_PRESS],
+        entity_registry_enabled_default=False,  # 长按默认禁用
+    )
+    ROTATE = TerncyButtonDescription(
+        key=ACTION_ROTATION,
+        sub_key=ACTION_ROTATION,
+        translation_key=ACTION_ROTATION,
+        event_types=[ACTION_ROTATION],
+        entity_registry_enabled_default=False,  # 旋转默认禁用
+    )
+    extra_descriptions = [SINGLE, DOUBLE, LONG]
+
     for profile in EVENT_ENTITY_EVENTS_MAP:
+        event_types = list(EVENT_ENTITY_EVENTS_MAP.get(profile))
         button_desc = TerncyButtonDescription(
-            event_types=list(EVENT_ENTITY_EVENTS_MAP.get(profile))
+            event_types=event_types,
+            entity_registry_enabled_default=False,  # 旧版的通用按钮实体默认禁用
         )
-        PROFILES.get(profile).append(button_desc)
+        descriptions = PROFILES.get(profile)
+        descriptions.append(button_desc)
+        # 为最常用的 单击、双击、长按 再单独创建一个 event 实体
+        descriptions.extend(extra_descriptions)
+        # 支持旋转的话就再加个旋转
+        if ACTION_ROTATION in event_types:
+            descriptions.append(ROTATE)

--- a/custom_components/terncy/translations/en.json
+++ b/custom_components/terncy/translations/en.json
@@ -79,6 +79,46 @@
             }
           }
         }
+      },
+      "single_press": {
+        "name": "Single Press",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "single_press": "Single Press"
+            }
+          }
+        }
+      },
+      "double_press": {
+        "name": "Double Press",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "double_press": "Double Press"
+            }
+          }
+        }
+      },
+      "long_press": {
+        "name": "Long Press",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "long_press": "Long Press"
+            }
+          }
+        }
+      },
+      "rotation": {
+        "name": "Rotation",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "rotation": "Rotation"
+            }
+          }
+        }
       }
     }
   },

--- a/custom_components/terncy/translations/zh-Hans.json
+++ b/custom_components/terncy/translations/zh-Hans.json
@@ -54,6 +54,46 @@
             }
           }
         }
+      },
+      "single_press": {
+        "name": "单击",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "single_press": "单击"
+            }
+          }
+        }
+      },
+      "double_press": {
+        "name": "双击",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "double_press": "双击"
+            }
+          }
+        }
+      },
+      "long_press": {
+        "name": "长按",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "long_press": "长按"
+            }
+          }
+        }
+      },
+      "rotation": {
+        "name": "旋转",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "rotation": "旋转"
+            }
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
把几个常用的点击事件做成了单独的实体，使用起来可以方便一些。

之前的按钮实体依旧保留，不会破坏原有的自动化。

（双击、长按、旋转 和 旧的按钮 都默认禁用了，需要的用户可以自行在实体列表里批量启用）

---

另外，修复了 event 实体禁用时 触发会报错的问题。