### PR TITLE
update host when zeroconf discovery

### DIFF
--- a/custom_components/terncy/config_flow.py
+++ b/custom_components/terncy/config_flow.py
@@ -8,7 +8,13 @@ import terncy
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, OptionsFlow
-from homeassistant.const import CONF_DEVICE, CONF_PORT, MAJOR_VERSION, MINOR_VERSION
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_HOST,
+    CONF_PORT,
+    MAJOR_VERSION,
+    MINOR_VERSION,
+)
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
@@ -104,7 +110,7 @@ class TerncyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("async_step_begin_pairing: %s", user_input)
         if self.unique_id is None:
             await self.async_set_unique_id(self.identifier)
-            self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured(updates={CONF_HOST: self.host})
         ternobj = _get_terncy_instance(self)
         if self.token == "":
             _LOGGER.warning("request a new token form terncy %s", self.identifier)
@@ -163,7 +169,7 @@ class TerncyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         identifier = discovery_info.name
         identifier = identifier.replace("." + TERNCY_HUB_SVC_NAME, "")
         await self.async_set_unique_id(identifier)
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
 
         properties = discovery_info.properties
         _LOGGER.debug(properties)


### PR DESCRIPTION
`config_entry` 的 `data` 里存的 IP 一直是第一次配对成功时候的 IP 没有更新，这里在收到 zeroconf 消息的时候更新一下。

（应该没有什么实际影响，我之前不更新这个值也运行得挺正常的）